### PR TITLE
Remove spec information from example/cluster/cluster.yaml

### DIFF
--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -19,7 +19,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: BareMetalCluster
 metadata:
   name: ${CLUSTER_NAME}
-spec:
-  cloudName: ${CLUSTER_NAME}
-  cloudsSecret:
-    name: cloud-config
+# spec:
+#   cloudName: ${CLUSTER_NAME}
+#   cloudsSecret:
+#     name: cloud-config

--- a/go.mod
+++ b/go.mod
@@ -54,5 +54,5 @@ replace (
 	sigs.k8s.io/cluster-api => github.com/keleustes/cluster-api v1.16.1
 	sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm => github.com/keleustes/cluster-api-bootstrap-provider-kubeadm v1.16.1
 	sigs.k8s.io/controller-runtime => github.com/keleustes/controller-runtime v1.16.1
-	sigs.k8s.io/kustomize/v3 => github.com/keleustes/kustomize/v3 v3.16.1
+	sigs.k8s.io/kustomize/v3 => github.com/keleustes/kustomize/v3 v3.16.4
 )


### PR DESCRIPTION
- Remove specs to allow example to deploy successfully
- Rebuild image with new BareMetalCluster definition
