### PR TITLE
Add spec.clusterName field to controlplane and machinedeployment CRs

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -23,6 +23,7 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-0
 spec:
+  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"
@@ -70,6 +71,7 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-1
 spec:
+  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"
@@ -111,6 +113,7 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-2
 spec:
+  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -36,11 +36,11 @@ metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   template:
-    clusterName: ${CLUSTER_NAME}
     spec:
       image:
         url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
         checksum: "97830b21ed272a3d854615beb54cf004"
+      clusterName: ${CLUSTER_NAME} 
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
This PR adding missing spec.clusterName field into controlplane.yaml and machinedeployment.yaml in examples/controlplane and examples/machinedeployment folders.