### PR TITLE
Fetch user data from a bootstrap provider secret

### DIFF
--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -40,7 +40,7 @@ spec:
       image:
         url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
         checksum: "97830b21ed272a3d854615beb54cf004"
-      clusterName: ${CLUSTER_NAME} 
+      clusterName: ${CLUSTER_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
This PR is updating baremetalmachine manager to fulfill the requirements of v1alpha3 changes defined in: https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md -> Data generated from a bootstrap provider is now stored in a secret